### PR TITLE
feat(renovate): add minimumReleaseAge of 7 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "assignees": ["yteraoka"],
   "extends": [
     "config:base"
-  ]
+  ],
+  "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## Summary

- Renovate がリリースから7日経過したパッケージのみ PR を作成するよう `minimumReleaseAge: "7 days"` を追加

## Why

リリース直後に発覚したバグへの即時 patch など、不安定なリリースを取り込むリスクを減らすため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)